### PR TITLE
Avoid warning in case `referrerblocked.txt` is not readable

### DIFF
--- a/src/Resources/contao/classes/Referrer/Blocker.php
+++ b/src/Resources/contao/classes/Referrer/Blocker.php
@@ -80,7 +80,7 @@ class Blocker
         if (false === $blocklist) 
         {
             $referrerlist = $this->getCachePath() .'/referrerblocked.txt';
-            $blocklist    = file_get_contents($referrerlist);
+            $blocklist    = @file_get_contents($referrerlist) ?: 'Failed to open stream';
         }
 
         if (substr_count($blocklist, '|'. $this->getReferrer() .'|')) 


### PR DESCRIPTION
In case the file `/var/cache/dev/botdetection/referrerblocked.txt` is not readable or could not be downloaded (e.g., when Contao runs behind a proxy), a `failed to open stream` is thrown:

![image](https://github.com/user-attachments/assets/b2e742ac-6c33-4820-9a96-14ff0308f1a7)
